### PR TITLE
Fix SessionContextType error in home page

### DIFF
--- a/app/home/page.tsx
+++ b/app/home/page.tsx
@@ -1,7 +1,7 @@
 import Sidebar from "@/components/Sidebar";
 import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
-import { SessionContext, SessionContextType } from "@/lib/session-context";
+import { SessionContext } from "@/lib/session-context";
 import { db } from '@/lib/firebase';
 import { collection, doc, getDocs, onSnapshot, query, setDoc } from "firebase/firestore";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -14,7 +14,7 @@ interface UserData {
   online?: boolean;
 }
 export default function Home() {
-  const { user, loading, firebaseClient } = useContext<SessionContextType>(SessionContext);
+  const { user, loading, firebaseClient } = useContext(SessionContext);
   const router = useRouter();
   const [users, setUsers] = useState<UserData[]>([]);
 

--- a/lib/session-context.tsx
+++ b/lib/session-context.tsx
@@ -6,9 +6,10 @@ import { doc, setDoc } from 'firebase/firestore';
 interface SessionContextType {
   user: User | null;
   loading: boolean;
+  firebaseClient: any | null;
 }
 
-export const SessionContext = createContext<SessionContextType | null>(null);
+export const SessionContext = createContext<SessionContextType>({ user: null, loading: true, firebaseClient: null });
 
 interface SessionContextProviderProps {
   children: ReactNode;
@@ -17,6 +18,7 @@ interface SessionContextProviderProps {
 export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
+  const [firebaseClient, setFirebaseClient] = useState<any | null>(null);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -40,7 +42,7 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
   }, []);
 
   return (
-    <SessionContext.Provider value={{ user, loading }}>
+    <SessionContext.Provider value={{ user, loading, firebaseClient }}>
       {children}
     </SessionContext.Provider>
   );


### PR DESCRIPTION
Fix the type error in `SessionContext` and update `Home` component to use the updated context.

* **lib/session-context.tsx**
  - Add `firebaseClient` to `SessionContextType`.
  - Initialize `SessionContext` with `createContext<SessionContextType>({ user: null, loading: true, firebaseClient: null })`.
  - Include `firebaseClient` in the `SessionContext.Provider` value.

* **app/home/page.tsx**
  - Remove the type argument `<SessionContextType>` from `useContext`.
  - Destructure `firebaseClient` from `useContext(SessionContext)`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-ai/pull/7?shareId=04de3e8c-080d-40d8-b25d-4cd217ad8967).