### PR TITLE
Fix auth handling and default login page

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -12,7 +12,7 @@ export default function LoginPage() {
   useEffect(() => {
     const unsubscribe = auth.onAuthStateChanged((user: User | null) => {
       if (user) {
-        router.push('/');
+        router.push('/home');
       }
     });
 

--- a/lib/session-context.tsx
+++ b/lib/session-context.tsx
@@ -2,6 +2,7 @@ import React, { createContext, useState, useEffect, ReactNode } from 'react';
 import { auth, db } from './firebase';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
+import { useRouter } from 'next/router';
 
 interface SessionContextType {
   user: User | null;
@@ -19,6 +20,7 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [firebaseClient, setFirebaseClient] = useState<any | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -34,12 +36,13 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
         setUser(user);
       } else {
         setUser(null);
+        router.push('/login');
       }
       setLoading(false);
     });
 
     return () => unsubscribe();
-  }, []);
+  }, [router]);
 
   return (
     <SessionContext.Provider value={{ user, loading, firebaseClient }}>


### PR DESCRIPTION
Update authentication handling and redirection logic.

* **app/login/page.tsx**
  - Change redirect path to `/home` if the user is already logged in.

* **lib/session-context.tsx**
  - Import `useRouter` from 'next/router'.
  - Add a check to redirect to `/login` if the user is not logged in.
  - Update the dependency array of the `useEffect` hook to include `router`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-ai/pull/9?shareId=35f92258-9a28-4276-964b-07a87b383dc7).