### PR TITLE
Fix NextRouter mount error in SessionContextProvider

### DIFF
--- a/lib/session-context.tsx
+++ b/lib/session-context.tsx
@@ -2,7 +2,7 @@ import React, { createContext, useState, useEffect, ReactNode } from 'react';
 import { auth, db } from './firebase';
 import { onAuthStateChanged, User } from 'firebase/auth';
 import { doc, setDoc } from 'firebase/firestore';
-import { useRouter } from 'next/router';
+import { useRouter } from 'next/navigation';
 
 interface SessionContextType {
   user: User | null;
@@ -20,7 +20,12 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [firebaseClient, setFirebaseClient] = useState<any | null>(null);
-  const router = useRouter();
+  const [router, setRouter] = useState<any | null>(null);
+
+  useEffect(() => {
+    const routerInstance = useRouter();
+    setRouter(routerInstance);
+  }, []);
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {
@@ -36,7 +41,9 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
         setUser(user);
       } else {
         setUser(null);
-        router.push('/login');
+        if (router) {
+          router.push('/login');
+        }
       }
       setLoading(false);
     });


### PR DESCRIPTION
Fix the 'NextRouter was not mounted' error in `SessionContextProvider` component.

* Import `useRouter` from `next/navigation` instead of `next/router`.
* Move the `useRouter` hook inside a `useEffect` hook to ensure it is only called after the component is mounted.
* Update the `useEffect` hook to set the router only after the component is mounted.
* Add a check to ensure `router.push('/login')` is only called if the router is available.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-ai/pull/11?shareId=61aaed6e-74c2-4e5e-bac2-330929878d68).