### PR TITLE
Fix invalid hook call error in session context

### DIFF
--- a/lib/session-context.tsx
+++ b/lib/session-context.tsx
@@ -20,12 +20,7 @@ export const SessionContextProvider: React.FC<SessionContextProviderProps> = ({ 
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [firebaseClient, setFirebaseClient] = useState<any | null>(null);
-  const [router, setRouter] = useState<any | null>(null);
-
-  useEffect(() => {
-    const routerInstance = useRouter();
-    setRouter(routerInstance);
-  }, []);
+  const router = useRouter();
 
   useEffect(() => {
     const unsubscribe = onAuthStateChanged(auth, async (user) => {


### PR DESCRIPTION
Resolve Invalid hook call error in `lib/session-context.tsx`.

* Move `useRouter` call inside the `SessionContextProvider` function component.
* Remove `useEffect` hook that sets `router` state.
* Update `useEffect` hook to use `useRouter` directly.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-ai/pull/12?shareId=69fbd6b1-d5c4-460f-a910-4beb5e47b1ae).