### PR TITLE
Add recent chats section to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import { useContext, useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { SessionContext } from "@/lib/session-context";
-import { db } from '@/lib/firebase';
+import { db, fetchRecentChats } from '@/lib/firebase';
 import { collection, doc, addDoc, onSnapshot, query, setDoc, orderBy, limit } from "firebase/firestore";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -189,6 +189,16 @@ export default function Home() {
     return () => unsubscribe();
   }, [user]);
 
+  // Fetch recent chats
+  useEffect(() => {
+    const fetchChats = async () => {
+      const chats = await fetchRecentChats();
+      setRecentChats(chats);
+    };
+
+    fetchChats();
+  }, []);
+
   // Handle sending a message
   const handleSendMessage = async (chatId: string, text: string) => {
     if (!user || !text.trim()) return;
@@ -368,6 +378,21 @@ export default function Home() {
               </div>
             </TabsContent>
           </Tabs>
+
+          {/* Recent Chats Section */}
+          <section className="mt-8">
+            <h2 className="text-2xl font-bold mb-4">Recent Chats</h2>
+            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+              {recentChats.map(chat => (
+                <ChatTile 
+                  key={chat.chatId}
+                  user={chat.user}
+                  lastMessage={chat.lastMessage}
+                  onClick={() => router.push(`/chat/${chat.chatId}`)}
+                />
+              ))}
+            </div>
+          </section>
         </div>
       </main>
     </div>

--- a/lib/firebase.ts
+++ b/lib/firebase.ts
@@ -1,6 +1,6 @@
 import { initializeApp, getApps, FirebaseApp } from 'firebase/app';
 import { getAuth, GoogleAuthProvider, signInWithEmailAndPassword } from 'firebase/auth';
-import { getFirestore, doc, setDoc, collection, addDoc, getDocs } from 'firebase/firestore';
+import { getFirestore, doc, setDoc, collection, addDoc, getDocs, query, orderBy } from 'firebase/firestore';
 
 const firebaseConfig = {
   apiKey: "AIzaSyDAnH4Hm54GJ6h5gQMtExwJolE8FbHNBBg",
@@ -81,7 +81,8 @@ export const addAiGlobalRequestToFirestore = async (request: any) => {
 
 export const fetchRecentChats = async () => {
   const recentChatsCollection = collection(db, 'recentChats');
-  const snapshot = await getDocs(recentChatsCollection);
+  const recentChatsQuery = query(recentChatsCollection, orderBy("timestamp", "desc"));
+  const snapshot = await getDocs(recentChatsQuery);
   const recentChats = snapshot.docs.map(doc => doc.data());
   return recentChats;
 };


### PR DESCRIPTION
Add a section for recent chats in `app/page.tsx` and fetch recent chats from Firestore.

* **app/page.tsx**
  - Import `fetchRecentChats` from `lib/firebase.ts`.
  - Add a `useEffect` hook to fetch recent chats and set them in state.
  - Add a section to display recent chats using the `ChatTile` component.

* **lib/firebase.ts**
  - Modify `fetchRecentChats` function to order chats by timestamp in descending order.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/00YellowLemon/converse-ai/pull/24?shareId=6bfccb0c-fed2-4785-b392-d32668375155).